### PR TITLE
Fix Unicode escaping in migrated YAML

### DIFF
--- a/custom_components/template_migration/__init__.py
+++ b/custom_components/template_migration/__init__.py
@@ -41,6 +41,8 @@ def create_migrated_file(path: Path, configs: list[ConfigType]) -> None:
             configs,
             yaml_file,
             Dumper=TemplateDumper,
+            allow_unicode=True,
+            sort_keys=False,
         )
     _LOGGER.info("Created migrated template YAML file at %s", path)
 


### PR DESCRIPTION
# What
Fix Unicode / accented character escaping in generated migration YAML.

### Why
Currently PyYAML escapes non-ASCII characters (e.g. Hungarian accents) into `\x..` / `\u....`, so entity names look wrong in Home Assistant.

### How
Add `allow_unicode=True` to the `yaml.dump()` call in `create_migrated_file()` (also set `sort_keys=False` for nicer output). Tested locally.

```python
yaml.dump(
    configs,
    yaml_file,
    Dumper=TemplateDumper,
    allow_unicode=True,
    sort_keys=False,
)